### PR TITLE
Render items only when recipes are populated

### DIFF
--- a/client/src/routes/ListDetail.jsx
+++ b/client/src/routes/ListDetail.jsx
@@ -30,33 +30,14 @@ const ListDetail = () => {
         populateListInfo();
     }, [listId])
 
-    useEffect(() => {
-        mapRecipesToItems();
-    }, [recipes])
-
-    const mapRecipesToItems = () => {
-        if (recipes.length === 0) {
-            return;
-        }
-        const retval = initializeRecipesForItems();
-
+    const getRecipesForItem = (itemName) => {
+        const retval = []
         for (const recipe of recipes) {
-            for (const item of recipe.items) {
-                retval[item.name].push({
-                    title: recipe.title,
-                    id: recipe.id
-                });
+            if (recipe.items.map((x) => x.name).includes(itemName)) {
+                retval.push(recipe);
             }
         }
 
-        setRecipesForItems(retval);
-    }
-
-    const initializeRecipesForItems = () => {
-        const retval = [];
-        for (const item of items) {
-            retval[item.name] = []
-        }
         return retval;
     }
 
@@ -108,12 +89,12 @@ const ListDetail = () => {
                 </div>
             </div>
             <div className="container">
-                {items && items.map((item) => {
+                {items && recipes && items.map((item) => {
                     return <Item 
                         key={item.id} 
                         name={item.name} 
                         id={item.id} 
-                        recipes={recipesForItems[item.name]}
+                        recipes={getRecipesForItem(item.name)}
                         tags={item.tags} 
                         quantity={item.quantity}
                         handleSubmitQuantity={(itemId, quantity) => updateItemQuantity(itemId, quantity)}


### PR DESCRIPTION
The previous solution to ensuring that an item's recipe members were updated required creating a state object that was nothing more than a remapping of existing state objects. This was necessary because I couldn't guarantee that either recipes would be populated on the first run-through, nor that rendered items could be updated without tracking a new state object containing exactly what was needed.

The conditional rendering allows all of this approach to be elided. Items will not be rendered until recipes are populated. A cost of this may be that I need to manually update the front end representation if the recipes object becomes updated.